### PR TITLE
Bugfix/61 fix discord responding

### DIFF
--- a/src/commands.py
+++ b/src/commands.py
@@ -30,7 +30,6 @@ class Command(ABC):
         Executes the command.
 
         Parameters:
-            db (DbHandler): The database handler object.
             message (discord.Message): The message containing the command and its parameters.
         """
 

--- a/src/discord_bot.py
+++ b/src/discord_bot.py
@@ -121,18 +121,23 @@ class DiscordBot:
         Returns:
             None
         """
-        print(f"Received message: {message.content}")
         # Ensure the bot doesn't respond to itself
         if message.author == self.client.user:
             return
-        # Check if the message starts with "!games"
+        
+        print(f"Received message: {message.content}")
+        # Check if the message is a command
         if message.content.startswith("!"):
-            command = self.command_factory.get_command(message.content)
-            if command is not None:
-                print("Command received:", message.content)
-                await command.execute(self.db, message)
-            else:
-                await message.channel.send("Unknown command. Type `!help` for a list of commands.")
+            try:
+                command = self.command_factory.get_command(message.content)
+                if command is not None:
+                    print("Command received:", message.content)
+                    await command.execute(message)
+                else:
+                    await message.channel.send("Unknown command. Type `!help` for a list of commands.")
+            except Exception as e:
+                print(f"An error occurred: {e}")
+                await message.channel.send("An error occurred while executing the command.")
 
     async def send_message(
             self,

--- a/src/discord_bot.py
+++ b/src/discord_bot.py
@@ -117,6 +117,7 @@ class DiscordBot:
         Returns:
             None
         """
+        print(f"Received message: {message.content}")
         # Ensure the bot doesn't respond to itself
         if message.author == self.client.user:
             return
@@ -124,10 +125,16 @@ class DiscordBot:
         if message.content.startswith("!"):
             if message.content == "!games":
                 # Ensure no extra spaces or newlines are present in each game name
-                await message.channel.send(
-                    "Games list: \n\n" +
-                    f"{self._make_list_printable(self.db.get_list_of_games())}"
-                )
+                print("Games command was called.")
+                print(self.db.get_list_of_games())
+                try:
+                    msg = await message.channel.send(
+                        "Games list: \n\n" +
+                        f"{_make_list_printable(self.db.get_list_of_games())}"
+                    )
+                except Exception as e:
+                    print(f"Error: {e}")
+                print("Message sent: ", msg.content)
             elif message.content.startswith("!games add "):
                 # Extract the game name
                 game = self._get_game_name_from_command(message, "!games add ")
@@ -163,7 +170,7 @@ class DiscordBot:
                     )
                 else:
                     await message.channel.send(
-                        f"Your game list: \n\n{self._make_list_printable(users_games)}"
+                        f"Your game list: \n\n{_make_list_printable(users_games)}"
                     )
             elif message.content.startswith("!mygames add "):
                 # Extract the game name
@@ -259,18 +266,18 @@ class DiscordBot:
         """
         return command.content[len(command_to_remove_from_message):].strip()
 
-    def _make_list_printable(items_list: list[str]) -> str:
-        """
-        Makes the lists items stripped of any extra white characters.
-        Every item will be on its separate line.
+def _make_list_printable(items_list: list[str]) -> str:
+    """
+    Makes the lists items stripped of any extra white characters.
+    Every item will be on its separate line.
 
-        Parameters:
-            items_list (List): The list of items to to be made printable.
+    Parameters:
+        items_list (List): The list of items to to be made printable.
 
-        Returns:
-            List: A new list of items from items_list separated by a new line.
-        """
-        return "\n".join(item.strip() for item in items_list)
+    Returns:
+        List: A new list of items from items_list separated by a new line.
+    """
+    return "\n".join(item.strip() for item in items_list)
 
 async def main() -> None:
     """
@@ -285,7 +292,7 @@ async def main() -> None:
     bot = DiscordBot()
 
     # Start the Discord bot in the background
-    bot_task = asyncio.create_task(bot.run())
+    await bot.run()
 
     # Wait for the bot to be ready
     await bot.wait_until_ready()
@@ -295,10 +302,7 @@ async def main() -> None:
     await bot.send_message("Just Testing")
 
     # On terminating the code
-    await bot.logout()
-
-    # Wait for the bot task to complete (or cancel it if needed)
-    await bot_task
+    # await bot.logout()
 
 if __name__ == '__main__':
     asyncio.run(main())

--- a/src/wheel_of_luck.py
+++ b/src/wheel_of_luck.py
@@ -340,7 +340,7 @@ async def main() -> None:
     # Each iteration represents a wheel spin
     while True:
         # Reads values from the applications main window
-        event, _ = main_window.read()
+        event, _ = main_window.read(timeout=100)
 
         # Pressing W/L buttons condition
         if event == "W":
@@ -348,16 +348,16 @@ async def main() -> None:
             db.insert_log_into_database(event)
             change_last_spin_insertion_visibility(main_window, db, False)
             continue
-        if event == "L":
+        elif event == "L":
             win_lose_msg.update("\nYOU SUCK")
             db.insert_log_into_database(event)
             change_last_spin_insertion_visibility(main_window, db, False)
             continue
-        if event == "SEND REACTION":
+        elif event == "SEND REACTION":
             rolled_game = None
             message_id = await bot.send_message("Let's spin the wheel of luck! Who's in?")
             continue
-        if event == "PLAY REACTION":
+        elif event == "PLAY REACTION":
             # Check that there is a message already sent in the DC chat
             if message_id is None:
                 print("You have to send a reaction message first.")
@@ -404,19 +404,22 @@ async def main() -> None:
             # Show insertion
             change_last_spin_insertion_visibility(main_window, db, True)
             continue
-        if  event == "ANNOUNCE":
+        elif event == "ANNOUNCE":
             if rolled_game is not None:
                 # Call Discord Bot to announce the game that has been rolled
                 await bot.send_message(
                     "Going to play " + rolled_game.Get() + ", anyone wanna join in?"
                 )
             continue
-        # Window closing event
-        # Properly shutting down the bot and its loop
-        await bot.logout()
-        # Wait for the logout operation to end, closing the discord bot thread
-        await bot_task
-        break
+        elif event == PySimpleGUI.WIN_CLOSED:
+            # Properly shutting down the bot and its loop
+            await bot.logout()
+            # Wait for the logout operation to end, closing the discord bot thread
+            await bot_task
+            main_window.close()
+            break
+        # Yield control back to the event loop
+        await asyncio.sleep(0.1)
 
 if __name__ == "__main__":
     # Create an event loop for the main function


### PR DESCRIPTION
Discord bot wasn't responding to commands in DC chat because the app UI blocked the event loop by waiting on button clicks.

Fix this by `event, _ = main_window.read(timeout=100)`, adding timeout to window reading, making it return the window state and then `await asyncio.sleep(0.1)` to let the event loop handle incoming commands from the chat. This approach works for our purposes, but is not scalable, therefore we can return to using a whole separate thread for the Discord bot in the future.